### PR TITLE
establish db tunnel to install process for db tunnel case

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -66,6 +66,7 @@ fi
 cd lupmgr && git pull && git checkout ${BRANCH}
 
 echo "export LIGHTUP_TLA=${LIGHTUP_TLA}" > user_config.sh
+echo "export INSTALL_DATAPLANE=${INSTALL_DATAPLANE}" >> user_config.sh
 echo "export LIGHTUP_DATAPLANE_USERNAME=$(whoami)" >> user_config.sh
 echo "export LIGHTUP_DATAPLANE_LUPMGR_DIR=$(pwd)" >> user_config.sh
 echo "export LIGHTUP_DATAPLANE_HOMEDIR=${HOME}" >> user_config.sh

--- a/generate_command.sh
+++ b/generate_command.sh
@@ -7,6 +7,18 @@ source utils.sh
 this_dir=$(pwd)
 private_ip=$(discover_private_ip)
 
+reverse_port_list="-R ${LIGHTUP_CONNECT_MAPPED_PORT}:localhost:22 "
+if [[ $INSTALL_DATAPLANE = "1" ]]
+then
+	reverse_port_list="${reverse_port_list} \
+	-R 0.0.0.0:${LIGHTUP_DATAPLANE_ADMIN_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_ADMIN_PORT} \
+	-R 0.0.0.0:${LIGHTUP_DATAPLANE_APP_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_APP_PORT} \
+	-R 0.0.0.0:${LIGHTUP_DATAPLANE_K8S_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_K8S_PORT}"
+else
+	reverse_port_list="${reverse_port_list} \
+	-R 0.0.0.0:${DB_PORT}:${DB_HOST}:${DB_PORT}"
+fi
+
 echo  \
 "AUTOSSH_DEBUG=1 \
 AUTOSSH_LOGFILE=${this_dir}/autossh.log \
@@ -17,8 +29,5 @@ autossh -f -M 0 ${LIGHTUP_CONNECT_USER_NAME}@${LIGHTUP_CONNECT_SERVER_NAME} -p $
 	-o StrictHostKeyChecking=no \
 	-o ServerAliveInterval=30 \
 	-o ServerAliveCountMax=3 \
-	-R ${LIGHTUP_CONNECT_MAPPED_PORT}:localhost:22 \
-	-R 0.0.0.0:${LIGHTUP_DATAPLANE_ADMIN_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_ADMIN_PORT} \
-	-R 0.0.0.0:${LIGHTUP_DATAPLANE_APP_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_APP_PORT} \
-	-R 0.0.0.0:${LIGHTUP_DATAPLANE_K8S_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_K8S_PORT} \
+	${reverse_port_list} \
 	-vvv -i $this_dir/keys/${LIGHTUP_CONNECT_KEYPAIR_NAME}"


### PR DESCRIPTION
If it is db tunnel mode, we set up reverse tunnel with the DB port and ssh port. When system is restarted, reconnect the tunnel automatically.