### PR TITLE
Seperate reverse SSH tunnel from other tunnels

### DIFF
--- a/connect.sh
+++ b/connect.sh
@@ -9,9 +9,14 @@ set -x
 
 this_dir=$(pwd)
 
-if [[ -f autossh.pid ]]; then
-	echo "ERROR: autossh.pid already exists, not starting another autossh, run ./disconnect.sh first and then try again"
+if [[ -f autossh-connect.pid ]]; then
+	echo "ERROR: autossh-connect.pid already exists, not starting another autossh, run ./disconnect.sh first and then try again"
 	exit 1
+fi
+
+if [[ -f autossh-dataplane.pid ]]; then
+    echo "ERROR: autossh-dataplane.pid already exists, not starting another autossh, run ./disconnect.sh first and then try again"
+    exit 1
 fi
 
 mkdir -p generated
@@ -33,7 +38,11 @@ if [[ ! $err -eq "0" ]]; then
 	tail /var/log/syslog | grep autossh
 	echo
 
-	echo "** output of cat autossh.log:"
-	cat autossh.log
+	echo "** output of cat autossh-dataplane.log:"
+	cat autossh-dataplane.log
 	echo
+
+    echo "** output of cat autossh-connect.log:"
+    cat autossh-connect.log
+    echo
 fi

--- a/disconnect.sh
+++ b/disconnect.sh
@@ -6,7 +6,8 @@ source user_config.sh
 source fixed_config.sh
 
 echo "killing autossh by pid first..."
-( [[ ! -f autossh.pid ]] && echo "no autossh.pid file found" ) || ( cat autossh.pid && sudo kill $(cat autossh.pid) )
+( [[ ! -f autossh-dataplane.pid ]] && echo "no autossh-dataplane.pid file found" ) || ( cat autossh-dataplane.pid && sudo kill $(cat autossh-dataplane.pid) )
+( [[ ! -f autossh-connect.pid ]] && echo "no autossh-connect.pid file found" ) || ( cat autossh-connect.pid && sudo kill $(cat autossh-connect.pid) )
 echo
 
 echo "killing autossh by regex..."
@@ -20,5 +21,7 @@ echo "** output of ps aux | grep autossh:"
 ps aux | grep autossh
 echo
 
-sudo rm -rf autossh.pid
-sudo rm -rf autossh.log
+sudo rm -rf autossh-dataplane.pid
+sudo rm -rf autossh-dataplane.log
+sudo rm -rf autossh-connect.pid
+sudo rm -rf autossh-connect.log

--- a/generate_command.sh
+++ b/generate_command.sh
@@ -7,22 +7,20 @@ source utils.sh
 this_dir=$(pwd)
 private_ip=$(discover_private_ip)
 
-reverse_port_list="-R ${LIGHTUP_CONNECT_MAPPED_PORT}:localhost:22 "
 if [[ $INSTALL_DATAPLANE = "1" ]]
 then
-	reverse_port_list="${reverse_port_list} \
+	reverse_port_list="\
 	-R 0.0.0.0:${LIGHTUP_DATAPLANE_ADMIN_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_ADMIN_PORT} \
 	-R 0.0.0.0:${LIGHTUP_DATAPLANE_APP_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_APP_PORT} \
 	-R 0.0.0.0:${LIGHTUP_DATAPLANE_K8S_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_K8S_PORT}"
 else
-	reverse_port_list="${reverse_port_list} \
-	-R 0.0.0.0:${DB_PORT}:${DB_HOST}:${DB_PORT}"
+	reverse_port_list="-R 0.0.0.0:${DB_PORT}:${DB_HOST}:${DB_PORT}"
 fi
 
 echo  \
 "AUTOSSH_DEBUG=1 \
-AUTOSSH_LOGFILE=${this_dir}/autossh.log \
-AUTOSSH_PIDFILE=${this_dir}/autossh.pid \
+AUTOSSH_LOGFILE=${this_dir}/autossh-dataplane.log \
+AUTOSSH_PIDFILE=${this_dir}/autossh-dataplane.pid \
 autossh -f -M 0 ${LIGHTUP_CONNECT_USER_NAME}@${LIGHTUP_CONNECT_SERVER_NAME} -p ${LIGHTUP_CONNECT_SERVER_PORT} -N \
 	-o ExitOnForwardFailure=yes \
 	-o UserKnownHostsFile=/dev/null \
@@ -31,3 +29,15 @@ autossh -f -M 0 ${LIGHTUP_CONNECT_USER_NAME}@${LIGHTUP_CONNECT_SERVER_NAME} -p $
 	-o ServerAliveCountMax=3 \
 	${reverse_port_list} \
 	-vvv -i $this_dir/keys/${LIGHTUP_CONNECT_KEYPAIR_NAME}"
+echo  \
+"AUTOSSH_DEBUG=1 \
+AUTOSSH_LOGFILE=${this_dir}/autossh-connect.log \
+AUTOSSH_PIDFILE=${this_dir}/autossh-connect.pid \
+autossh -f -M 0 ${LIGHTUP_CONNECT_USER_NAME}@${LIGHTUP_CONNECT_SERVER_NAME} -p ${LIGHTUP_CONNECT_SERVER_PORT} -N \
+    -o ExitOnForwardFailure=yes \
+    -o UserKnownHostsFile=/dev/null \
+    -o StrictHostKeyChecking=no \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -R ${LIGHTUP_CONNECT_MAPPED_PORT}:localhost:22 \
+    -vvv -i $this_dir/keys/${LIGHTUP_CONNECT_KEYPAIR_NAME}"


### PR DESCRIPTION
Split up the reverse ssh tunnel from the other tunnels.

https://app.asana.com/0/1107674812845927/1201188821997019/f

Test environment still up here:
https://app.jefftest.lightup.ai/#/login
https://connect.jefftest.lightup.ai:8800/secure-console

Tested by installing from this branch:
```
LIGHTUP_BRANCH="users/jeff/split-ssh-tunnels" LIGHTUP_TLA=jefftest LIGHTUP_TOKEN=3f0648da-c0d6-4add-9854-9462969d61ca bash < <(curl -H 'Cache-Control: no-cache' -L https://raw.githubusercontent.com/lupfoss/lupmgr/main/bootstrap.sh )
```

Tunnels on customer machine:
```
ubuntu@ip-172-31-22-40:~$ ps aux | grep autossh
ubuntu    685958  0.0  0.0   2504    92 ?        Ss   21:22   0:00 /usr/lib/autossh/autossh    -M 0 ubuntu@connect.jefftest.lightup.ai -p 22 -N -o ExitOnForwardFailure=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -R 0.0.0.0:8800:172.31.22.40:8800 -R 0.0.0.0:8443:172.31.22.40:8443 -R 0.0.0.0:8080:172.31.22.40:8080 -vvv -i /home/ubuntu/lupmgr/keys/jefftest-to-lightup
ubuntu    685965  0.0  0.0   2504    92 ?        Ss   21:22   0:00 /usr/lib/autossh/autossh    -M 0 ubuntu@connect.jefftest.lightup.ai -p 22 -N -o ExitOnForwardFailure=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -R 9000:localhost:22 -vvv -i /home/ubuntu/lupmgr/keys/jefftest-to-lightup
ubuntu    687576  0.0  0.0   8160  2404 pts/1    S+   21:22   0:00 grep --color=auto autossh
```

rc.local on customer machine:
```
ubuntu@ip-172-31-22-40:~$ cat /etc/rc.local
#!/usr/bin/env bash
AUTOSSH_DEBUG=1 AUTOSSH_LOGFILE=/home/ubuntu/lupmgr/autossh-dataplane.log AUTOSSH_PIDFILE=/home/ubuntu/lupmgr/autossh-dataplane.pid autossh -f -M 0 ubuntu@connect.jefftest.lightup.ai -p 22 -N 	-o ExitOnForwardFailure=yes 	-o UserKnownHostsFile=/dev/null 	-o StrictHostKeyChecking=no 	-o ServerAliveInterval=30 	-o ServerAliveCountMax=3 		-R 0.0.0.0:8800:172.31.22.40:8800 	-R 0.0.0.0:8443:172.31.22.40:8443 	-R 0.0.0.0:8080:172.31.22.40:8080 	-vvv -i /home/ubuntu/lupmgr/keys/jefftest-to-lightup
AUTOSSH_DEBUG=1 AUTOSSH_LOGFILE=/home/ubuntu/lupmgr/autossh-connect.log AUTOSSH_PIDFILE=/home/ubuntu/lupmgr/autossh-connect.pid autossh -f -M 0 ubuntu@connect.jefftest.lightup.ai -p 22 -N     -o ExitOnForwardFailure=yes     -o UserKnownHostsFile=/dev/null     -o StrictHostKeyChecking=no     -o ServerAliveInterval=30     -o ServerAliveCountMax=3     -R 9000:localhost:22     -vvv -i /home/ubuntu/lupmgr/keys/jefftest-to-lightup
```

Tunnels on connect VM:
```
ubuntu@ip-172-31-10-5:~/log$ netstat -lnut
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State
tcp        0      0 0.0.0.0:9000            0.0.0.0:*               LISTEN
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN
tcp        0      0 0.0.0.0:8443            0.0.0.0:*               LISTEN
tcp        0      0 0.0.0.0:8800            0.0.0.0:*               LISTEN
tcp6       0      0 :::9000                 :::*                    LISTEN
tcp6       0      0 :::8080                 :::*                    LISTEN
tcp6       0      0 :::22                   :::*                    LISTEN
tcp6       0      0 :::8443                 :::*                    LISTEN
tcp6       0      0 :::8800                 :::*                    LISTEN
udp        0      0 127.0.0.53:53           0.0.0.0:*
udp        0      0 172.31.10.5:68          0.0.0.0:*
```

Tested by rebooting the customer machine and making sure the tunnels are re-established. Also tested `./disconnect.sh` and `./connect.sh`.