### PR TITLE
Host specific SSH key name / Install only with no DB tunnel

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,7 @@ TOK=${LIGHTUP_TOKEN}
 BRANCH=${LIGHTUP_BRANCH:-main}
 INSTALL_DATAPLANE="${LIGHTUP_INSTALL:-1}"
 LIGHTUP_CONNECT_MAPPED_PORT="${CONNECT_PORT:-9000}"
+LIGHTUP_CONNECT_KEYPAIR_NAME="${LIGHTUP_TLA}-to-lightup-${HOSTNAME}-${LIGHTUP_CONNECT_MAPPED_PORT}"
 
 
 # determine distro
@@ -68,6 +69,7 @@ cd lupmgr && git pull && git checkout ${BRANCH}
 
 echo "export LIGHTUP_TLA=${LIGHTUP_TLA}" > user_config.sh
 echo "export INSTALL_DATAPLANE=${INSTALL_DATAPLANE}" >> user_config.sh
+echo "export LIGHTUP_CONNECT_KEYPAIR_NAME=${LIGHTUP_CONNECT_KEYPAIR_NAME}" >> user_config.sh
 echo "export LIGHTUP_CONNECT_MAPPED_PORT=${LIGHTUP_CONNECT_MAPPED_PORT}" >> user_config.sh
 echo "export LIGHTUP_DATAPLANE_USERNAME=$(whoami)" >> user_config.sh
 echo "export LIGHTUP_DATAPLANE_LUPMGR_DIR=$(pwd)" >> user_config.sh

--- a/fixed_config.sh
+++ b/fixed_config.sh
@@ -9,7 +9,6 @@ fi
 export LIGHTUP_CONNECT_SERVER_PORT=22
 
 # Do not edit the variables below:
-export LIGHTUP_CONNECT_KEYPAIR_NAME="${LIGHTUP_TLA}-to-lightup"
 export LIGHTUP_ACCEPT_KEYPAIR_NAME="lightup-to-${LIGHTUP_TLA}"
 export LIGHTUP_CONNECT_SERVER_NAME="connect.${LIGHTUP_TLA}.lightup.ai"
 export LIGHTUP_CONNECT_USER_NAME="ubuntu"

--- a/generate_command.sh
+++ b/generate_command.sh
@@ -14,21 +14,28 @@ then
 	-R 0.0.0.0:${LIGHTUP_DATAPLANE_APP_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_APP_PORT} \
 	-R 0.0.0.0:${LIGHTUP_DATAPLANE_K8S_PORT}:${private_ip}:${LIGHTUP_DATAPLANE_K8S_PORT}"
 else
-	reverse_port_list="-R 0.0.0.0:${DB_PORT}:${DB_HOST}:${DB_PORT}"
+	if [ -n "$DB_PORT" ] && [ -n "$DB_HOST" ]
+	then
+		reverse_port_list="-R 0.0.0.0:${DB_PORT}:${DB_HOST}:${DB_PORT}"
+	fi
 fi
 
-echo  \
-"AUTOSSH_DEBUG=1 \
-AUTOSSH_LOGFILE=${this_dir}/autossh-dataplane.log \
-AUTOSSH_PIDFILE=${this_dir}/autossh-dataplane.pid \
-autossh -f -M 0 ${LIGHTUP_CONNECT_USER_NAME}@${LIGHTUP_CONNECT_SERVER_NAME} -p ${LIGHTUP_CONNECT_SERVER_PORT} -N \
-	-o ExitOnForwardFailure=yes \
-	-o UserKnownHostsFile=/dev/null \
-	-o StrictHostKeyChecking=no \
-	-o ServerAliveInterval=30 \
-	-o ServerAliveCountMax=3 \
-	${reverse_port_list} \
-	-vvv -i $this_dir/keys/${LIGHTUP_CONNECT_KEYPAIR_NAME}"
+if [ -n "$reverse_port_list" ]
+then
+	echo  \
+	"AUTOSSH_DEBUG=1 \
+	AUTOSSH_LOGFILE=${this_dir}/autossh-dataplane.log \
+	AUTOSSH_PIDFILE=${this_dir}/autossh-dataplane.pid \
+	autossh -f -M 0 ${LIGHTUP_CONNECT_USER_NAME}@${LIGHTUP_CONNECT_SERVER_NAME} -p ${LIGHTUP_CONNECT_SERVER_PORT} -N \
+		-o ExitOnForwardFailure=yes \
+		-o UserKnownHostsFile=/dev/null \
+		-o StrictHostKeyChecking=no \
+		-o ServerAliveInterval=30 \
+		-o ServerAliveCountMax=3 \
+		${reverse_port_list} \
+		-vvv -i $this_dir/keys/${LIGHTUP_CONNECT_KEYPAIR_NAME}"
+fi
+
 echo  \
 "AUTOSSH_DEBUG=1 \
 AUTOSSH_LOGFILE=${this_dir}/autossh-connect.log \


### PR DESCRIPTION
- Add hostname and port number to the ssh key name
- Don't configure DB tunnel mode if either the port or host are missing

Tested with:

No install:
```
LIGHTUP_INSTALL=0 CONNECT_PORT=9002 LIGHTUP_TLA=jefftest LIGHTUP_TOKEN=XYZ ./bootstrap.sh
```
No install but with a fake DB tunnel:
```
DB_PORT=9010 DB_HOST=localhost LIGHTUP_INSTALL=0 CONNECT_PORT=9002 LIGHTUP_TLA=jefftest LIGHTUP_TOKEN=XYZ ./bootstrap.sh
```
And setup a second VM and again tested with no install:
```
LIGHTUP_INSTALL=0 CONNECT_PORT=9003 LIGHTUP_TLA=jefftest LIGHTUP_TOKEN=XYZ ./bootstrap.sh
```
For both VMs I made sure that we could ssh from the connect VM.