### PR TITLE
bootstrap: support environments where unbound variable checks are enabled

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,8 @@ if [[ -f /etc/redhat-release && $(grep -Eo 'release 8\.' /etc/redhat-release) ]]
 fi
 
 if [[ ${DISTRO-} = "" ]]; then
-    echo "error: distribution not supported"
+    echo "error: distro not supported, please see list of supported platforms at: "
+    echo "https://docs.lightup.ai/lightup-quickstart/deployment/lightup-hybrid-quick-start#create-a-vm"
     exit 1
 fi
 


### PR DESCRIPTION
bash could have unbound variable checks enabled (using `set -u`) - in those cases, we should setup default values). This PR sets it up for bootstrap so, the script doesn't exit abnormally. 

In addition, improved the error message to point to the documentation section.



```
bash-3.2$ echo ${DISTRO}

bash-3.2$ set -u
bash-3.2$ echo ${DISTRO}
bash: DISTRO: unbound variable
bash-3.2$ echo ${DISTRO-}

bash-3.2$ 
```