### PR TITLE
Cleanup prev lupmgr dir on tgz repo install

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -87,6 +87,7 @@ else
     LIGHTUP_TAR_GZ_TARGET="v${LIGHTUP_TAR_GZ_VERSION}.tar.gz"
     curl -H 'Cache-Control: no-cache' -L https://github.com/lupfoss/lupmgr/archive/refs/tags/"${LIGHTUP_TAR_GZ_TARGET}" --output lupmgr.tar.gz
     tar -xvf lupmgr.tar.gz
+    [[ -d lupmgr ]] && rm -rf lupmgr
     mv lupmgr-"${LIGHTUP_TAR_GZ_VERSION}" lupmgr
     cd lupmgr
 fi


### PR DESCRIPTION
If present delete the old `lupmgr` directory otherwise the `mv` will fail saying that the
directory isn't empty:
```
+ mv -f lupmgr-0.9.0 lupmgr
mv: rename lupmgr-0.9.0 to lupmgr/lupmgr-0.9.0: Directory not empty
```