### PR TITLE
Lightup Manager download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 Run the following commands with values provided to you for your account:
 
 ```
-curl -H 'Cache-Control: no-cache' -L https://raw.githubusercontent.com/lupfoss/lupmgr/v0.2.x/bootstrap.sh > bootstrap.sh && chmod +x bootstrap.sh
-LIGHTUP_TLA=<tla> LIGHTUP_TOKEN=<token> ./bootstrap.sh
+curl -H 'Cache-Control: no-cache' -L https://s3.us-west-2.amazonaws.com/www.lightup.ai/launch_lightup.sh | LIGHTUP_TLA=<tla> LIGHTUP_TOKEN=<token> bash -s install
 ```
 
 Examples:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,11 +2,7 @@
 
 set -eu -o pipefail
 
-# outside of repo - download init.sh
-BRANCH=${LIGHTUP_BRANCH:-main}
-curl -H 'Cache-Control: no-cache' -L https://raw.githubusercontent.com/lupfoss/lupmgr/$BRANCH/init.sh > init.sh
 source init.sh
-rm ../init.sh  # cleanup downloaded init.sh
 
 if ! systemctl is-active --quiet lightup-ssh-connect ; then
     source connect_ssh_to_lightup.sh

--- a/connect_dataplane_to_lightup.sh
+++ b/connect_dataplane_to_lightup.sh
@@ -7,16 +7,7 @@ if systemctl is-active --quiet lightup-dataplane-connect ; then
     exit 1
 fi
 
-if [ -f init.sh ]; then
-    source init.sh
-else
-    # outside of repo - download init.sh
-    BRANCH=${LIGHTUP_BRANCH:-main}
-    curl -H 'Cache-Control: no-cache' -L https://raw.githubusercontent.com/lupfoss/lupmgr/$BRANCH/init.sh > init.sh
-    source init.sh
-    rm ../init.sh  # cleanup downloaded init.sh
-fi
-
+source init.sh
 source user_config.sh
 source fixed_config.sh
 source utils.sh

--- a/connect_ssh_to_lightup.sh
+++ b/connect_ssh_to_lightup.sh
@@ -7,16 +7,7 @@ if systemctl is-active --quiet lightup-ssh-connect ; then
     exit 1
 fi
 
-if [ -f init.sh ]; then
-    source init.sh
-else
-    # outside of repo - download init.sh
-    BRANCH=${LIGHTUP_BRANCH:-main}
-    curl -H 'Cache-Control: no-cache' -L https://raw.githubusercontent.com/lupfoss/lupmgr/$BRANCH/init.sh > init.sh
-    source init.sh
-    rm ../init.sh  # cleanup downloaded init.sh
-fi
-
+source init.sh
 source user_config.sh
 source fixed_config.sh
 

--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,6 @@
 set -eu -o pipefail
 
 TOK=${LIGHTUP_TOKEN}
-BRANCH=${LIGHTUP_BRANCH:-main}
 HA_INSTALL="${LIGHTUP_HA_INSTALL:-0}"
 INSTALL_DATAPLANE="$(( ${LIGHTUP_INSTALL:-1} || HA_INSTALL ))"
 LIGHTUP_CONNECT_ADMIN_PORT="${CONNECT_ADMIN_PORT:-8800}"
@@ -76,20 +75,6 @@ if [[ ! -f lup-${NAME} ]]; then
     sudo chmod 440 lup-${NAME}
     sudo chown root:root lup-${NAME}
     sudo cp lup-${NAME} /etc/sudoers.d/
-fi
-
-if [[ -z "${LIGHTUP_TAR_GZ_VERSION}" ]]; then
-    echo "cloning lightup manager"
-    [[ -d lupmgr ]] || git clone https://github.com/lupfoss/lupmgr.git
-    cd lupmgr && git pull && git checkout ${BRANCH}
-else
-    echo "getting lightup manager"
-    LIGHTUP_TAR_GZ_TARGET="lupmgr-${LIGHTUP_TAR_GZ_VERSION}.tar.gz"
-    curl -H 'Cache-Control: no-cache' -L https://s3.us-west-2.amazonaws.com/www.lightup.ai/"${LIGHTUP_TAR_GZ_TARGET}" --output lupmgr.tar.gz
-    tar -xvf lupmgr.tar.gz
-    [[ -d lupmgr ]] && rm -rf lupmgr
-    mv lupmgr-"${LIGHTUP_TAR_GZ_VERSION}" lupmgr
-    cd lupmgr
 fi
 
 echo "export LIGHTUP_TLA=${LIGHTUP_TLA}" > user_config.sh

--- a/launch_lightup.sh
+++ b/launch_lightup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+BRANCH=${LIGHTUP_BRANCH:-main}
+DOWNLOAD_LOCATION=${LIGHTUP_DOWNLOAD_LOCATION:-"https://s3.us-west-2.amazonaws.com/www.lightup.ai/releases/lupmgr"}
+RELEASE=${LIGHTUP_RELEASE:-"latest"}
+
+# DOWNLOAD_LOCATION options are: a URL to download the repo, "git" to clone the repo, or
+# "local" for an already downloaded repo
+if [[ $DOWNLOAD_LOCATION = "git" ]]; then
+    echo "Cloning Lightup Manager"
+    [[ -d lupmgr ]] && rm -rf lupmgr
+    git clone https://github.com/lupfoss/lupmgr.git
+    cd lupmgr && git pull && git checkout ${BRANCH}
+elif [[ $DOWNLOAD_LOCATION != "local" ]]; then
+    echo "Downloading Lightup Manager..."
+    curl -H 'Cache-Control: no-cache' -L "${DOWNLOAD_LOCATION}"/"${RELEASE}/lupmgr.tar.gz" --output lupmgr.tar.gz
+    tar -xvf lupmgr.tar.gz
+    [[ -d lupmgr ]] && rm -rf lupmgr
+    mv lupmgr-* lupmgr
+    cd lupmgr
+fi
+
+case $1 in
+    install) source bootstrap.sh
+    ;;
+    connect_ssh_to_lightup) source connect_ssh_to_lightup.sh
+    ;;
+    connect_dataplane_to_lightup) source connect_dataplane_to_lightup.sh
+    ;;
+    "") echo "Lightup Manager downloaded to: $(pwd)"
+    ;;
+    *)
+    echo "unknown command: $1"
+    ;;
+esac


### PR DESCRIPTION
Add the script `launch_lightup.sh` that will download a `lupmgr` tar.gz release.
`launch_lightup.sh` will be copied to S3 so that it can be used to trigger the download
and install process by customers.