### PR TITLE
lupmgr preflight checks

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -10,6 +10,14 @@ LIGHTUP_CONNECT_APP_PORT="${CONNECT_APP_PORT:-8443}"
 LIGHTUP_CONNECT_MAPPED_PORT="${CONNECT_PORT:-9000}"
 LIGHTUP_CONNECT_KEYPAIR_NAME="${LIGHTUP_TLA}-to-lightup-${HOSTNAME}-${LIGHTUP_CONNECT_MAPPED_PORT}"
 
+# check user
+
+if [ `whoami` = root ]; then
+    echo "ERROR: Please do not run this script as root or using sudo"
+    exit 1
+else
+    echo "User '`whoami`' will be used for the installation"
+fi
 
 # determine distro
 

--- a/launch_lightup.sh
+++ b/launch_lightup.sh
@@ -29,6 +29,8 @@ case $1 in
     ;;
     connect_dataplane_to_lightup) source connect_dataplane_to_lightup.sh
     ;;
+    preflight_check) source preflight-check.sh
+    ;;
     "") echo "Lightup Manager downloaded to: $(pwd)"
     ;;
     *)

--- a/preflight-check.sh
+++ b/preflight-check.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+echo 'Running Lightup preflight checks...'
+
+echo 'Checking user...'
+if [ `whoami` = root ]; then
+    echo "ERROR: Please do not run this script as root or using sudo\n"
+    exit 1
+else
+    echo "  User '`whoami`' will be used for the installation"
+fi
+
+# Run replicated preflight checks
+# Start the standard install but exit after the host checks are run
+# TODO: Ideally this would use the release type that is being installed but 'head'
+# should be fine just for preflight checks
+echo 'Running Replicated preflight checks...'
+curl -sSL https://k8s.kurl.sh/lightup-head | sed 's/    install_host_dependencies/    exit 0/' | sudo bash
+EXIT=$?
+if [ $EXIT -eq 0 ]; then
+  echo Lightup preflight checks succeeded!
+else
+  echo ERROR: Lightup preflight checks failed
+  exit $EXIT
+fi


### PR DESCRIPTION
Allow the preflight checks from replicated to be run outside of the full installation.
These can then be run by a customer to make sure that their environment is good to go.
If additional checks are needed then they should be addeded in the lightup-replicated
repo.

Also, make sure that root / sudo isn't being used.